### PR TITLE
Fix minor typos

### DIFF
--- a/docs/setup/preliminaries.md
+++ b/docs/setup/preliminaries.md
@@ -8,7 +8,7 @@ _Note_: in the following instructions, terminal commands are prefixed by a virtu
 
 Kindly create in advance the various accounts for the **cloud services** we might use, _i.e._:
 
-* [Github](https://github.com/):
+* [Github](https://github.com/)
 * [Vagrant Cloud](https://vagrantcloud.com/)
 * [Docker Hub](https://hub.docker.com/)
 

--- a/tools/cli/modules.md
+++ b/tools/cli/modules.md
@@ -23,9 +23,9 @@ By loading appropriate environment modules, the user can select:
 * libraries, e.g. the MPI library, or
 * other third party software packages.
 
-An exhaustive list of the available software is proposed [in this page](https://hpc.uni.lu/users/software/).
+An exhaustive list of the available software is proposed [in this page](https://hpc-docs.uni.lu/software/swsets/).
 
-On a node, using an interactive jobs, you can:
+On a node, using an interactive job, you can:
 
 * list all available softwares: `module avail`
 * search for one software: `module spider <search terms>`
@@ -183,7 +183,7 @@ compile the following program, using GNU C++ compiler (`g++` command), and the I
 ### Fortran
 
 **Question:** create a new file `helloworld.f` containing the following source code,
-compile the following program, using the GNU Fortran compiler (`gfortran` command), and ICC (`ifortran` command).
+compile the following program, using the GNU Fortran compiler (`gfortran` command), and ICC (`ifort` command).
 
 
         program hello
@@ -223,7 +223,7 @@ In your home directory, create a file `mpi_broadcast.c` and copy the following s
                if (!rank) {
                     bcast_value = 42;
                }
-               MPI_Bcast(&bcast_value,1 ,MPI_INT, 0, MPI_COMM_WORLD );
+               MPI_Bcast(&bcast_value, 1, MPI_INT, 0, MPI_COMM_WORLD);
                printf("%s\t- %d - %d - %d\n", hostname, rank, size, bcast_value);
                fflush(stdout);
 
@@ -238,7 +238,7 @@ Reserve 2 tasks of 1 core on two distinct nodes with Slurm
 
 Load a toolchain and compile the code using `mpicc`
 
-        (node)$> mpicc mpi_broadcast.c -o mpi_broadcast -lpthread
+        (node)$> mpicc mpi_broadcast.c -o mpi_broadcast
 
 With Slurm, you can use the `srun` command. Create an interactive job, with 2 nodes (`-N 2`), and at least 2 tasks (`-n 2`).
 

--- a/tools/cli/modules.md
+++ b/tools/cli/modules.md
@@ -182,16 +182,13 @@ compile the following program, using GNU C++ compiler (`g++` command), and the I
 
 ### Fortran
 
-**Question:** create a new file `helloworld.f` containing the following source code,
+**Question:** create a new file `helloworld.f90` containing the following source code,
 compile the following program, using the GNU Fortran compiler (`gfortran` command), and ICC (`ifort` command).
 
 
         program hello
            print *, "Hello, World!"
         end program hello
-
-
-Be careful, the 6 spaces at the beginning of each line are required
 
 
 

--- a/tools/cli/modules.md
+++ b/tools/cli/modules.md
@@ -205,7 +205,6 @@ In your home directory, create a file `mpi_broadcast.c` and copy the following s
         #include <stdio.h>
         #include <mpi.h>
         #include <unistd.h>
-        #include <time.h> /* for the work function only */
 
         int main (int argc, char *argv []) {
                char hostname[257];


### PR DESCRIPTION
Found minor things to adjust within tools/cli/modules.md.

- Replace old URL for list of proposed software (currently points to old documentation)
- s/ifortran/ifort/ the compiler from Intel for Fortan language
- Fortran file extension .f90 does not require special space prefixes
- No need to compile and link mpi_broadcast.c with pthread, it's done automatically (with many other libs)
- Remove useless include in MPI example